### PR TITLE
Optimizations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pyyaml==3.11
 django-suit==0.2.11
 pytz==2015.4
 schedule==0.3.2
+cssselect
+urlnorm
+readability-lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.7.1
-newspaper==0.0.8
+newspaper
 tweepy==2.3.0
 python-dateutil==1.5
 tld==0.7.2

--- a/src/ExplorerArticle.py
+++ b/src/ExplorerArticle.py
@@ -1,0 +1,130 @@
+import newspaper
+import requests
+import logging
+from readability import Document
+import re
+import lxml.html
+
+class ExplorerArticle(object):#derive from object for getters/setters
+    def __init__(self, url):
+        self.url = url
+        self.canonical_url = url
+        self.newspaper_article = newspaper.Article(url)
+        self.newspaper_article.config.fetch_images = False
+        self.is_downloaded = False
+        self._readability_title = None
+        self._readability_text = None
+
+    def download(self):
+        '''
+        modified from https://github.com/codelucas/newspaper/blob/master/newspaper/network.py
+        '''
+        if(self.is_downloaded):
+            return True
+
+        FAIL_ENCODING = 'ISO-8859-1'
+        useragent = self.newspaper_article.config.browser_user_agent
+        timeout = self.newspaper_article.config.request_timeout
+
+        try:
+            html = None
+            response = requests.get(url=self.url)#TODO: add back get_request_kwargs functionality present in newspaper impl
+            if(response.status_code >= 400):
+                logging.warn(u"encountered status code {0} while getting {1}".format(response.status_code, self.url))
+                return False
+
+            if(not re.search("(text/html|application/xhtml\+xml|application/xml) *(; .*)?", response.headers["content-type"])):
+                logging.debug(u"not a html: {0}".format(response.headers["content-type"]))
+                return False
+
+            self.canonical_url = response.url
+
+            if response.encoding != FAIL_ENCODING:
+                html = response.text
+            else:
+                html = response.content
+            if not html:
+                return False
+
+            self.html = html
+            self.is_downloaded = True
+        except Exception as e:
+            logging.warn('%s on %s' % (e, self.url))
+            return False
+        return True
+
+    def preliminary_parse(self):
+        if(not self.is_downloaded):
+            raise Exception("not downloaded")
+        try:
+            d = Document(self.html)
+            self._readability_title = d.short_title()
+            self._readability_text = d.summary()
+            logging.debug(u"readability title: {0}".format(repr(self._readability_title)))
+            logging.debug(u"readability text: {0}".format(repr(self._readability_text)))
+            if(self._readability_title and self._readability_text):
+                return
+        except Exception as e:
+            logging.warning("error while doing readability parse: {0}".format(str(e)))
+
+        logging.debug("falling back to newspaper parse")
+        self.newspaper_article.parse()
+        logging.debug(u"newspaper title: {0}".format(repr(self._newspaper_title)))
+        logging.debug(u"newspaper text: {0}".format(repr(self._newspaper_text)))
+
+    def newspaper_parse(self):
+        return self.newspaper_article.parse()
+
+    @property
+    def html(self):
+        return self.newspaper_article.html
+
+    @html.setter
+    def html(self, value):
+        self.newspaper_article.download(value)
+
+    @property
+    def authors(self):
+        return self.newspaper_article.authors
+
+    @property
+    def _newspaper_title(self):
+        return self.newspaper_article.title
+
+    @property
+    def _newspaper_text(self):
+        return self.newspaper_article.text
+
+    @property
+    def title(self):
+        return self._readability_title or self._newspaper_title
+
+    @property
+    def text(self):
+        return self._readability_text or self._newspaper_text
+
+
+    def get_urls(self, article_text_links_only=False):
+        result = []
+        try:
+            if(article_text_links_only):
+                if(self._readability_text):
+                    lxml_tree = lxml.html.fromstring(self._readability_text)
+                else:
+                    if(not self.newspaper_article.is_parsed):
+                        self.newspaper_article.parse()
+                        if(self.newspaper_article.clean_top_node):
+                            lxml_tree = self.newspaper_article.clean_top_node
+                        else:
+                            logging.warning("no links could be obtained because both methods of obtaining a cleaned document failed")
+                            return []
+            else:
+                lxml_tree = lxml.html.fromstring(self.html)
+        except lxml.etree.Error as e:
+            logging.warning("error while getting links from article: {0}".format(str(e)))
+            return []
+        for e in lxml_tree.cssselect("a"):
+            href = e.get("href")
+            if(href):
+                result.append(href)
+        return result

--- a/src/article_explorer.py
+++ b/src/article_explorer.py
@@ -147,7 +147,7 @@ def parse_articles(referring_sites, db_keywords, source_sites, twitter_accounts_
 
             if((not keywords) or (not sources[0]) or (not twitter_accounts[0])):#[] gets coverted to false
                 logging.debug("skipping article because it's not a match")
-            #    continue
+                continue
             logging.info("match found")
 
             article.newspaper_parse()

--- a/src/article_explorer.py
+++ b/src/article_explorer.py
@@ -109,6 +109,8 @@ def parse_articles(referring_sites, db_keywords, source_sites, twitter_accounts_
         article_iterator = itertools.chain(iter(newspaper_articles), crawlersource_articles)
         processed = 0
         for article in article_iterator:
+            #have to put all the iteration stuff at the top because I used continue extensively in this loop
+            processed += 1
             print(
                 "%s (Article|%s) %i/%i          \r" %
                 (str(timezone.localtime(timezone.now()))[:-13],
@@ -234,10 +236,6 @@ def parse_articles(referring_sites, db_keywords, source_sites, twitter_accounts_
                                               domain=source[1], matched=False, local=(source[1] in site["url"]))
 
             warc_creator.create_article_warc(url)
-
-            processed += 1
-
-            logging.info("(%s | %i/%i) Finished looking: %s"%(article.url, processed, article_count, article.url))
         logging.info("Finished Site: %s"%site['name'])
         print(
             "%s (Article|%s) %i/%i          " %

--- a/src/article_explorer.py
+++ b/src/article_explorer.py
@@ -500,10 +500,11 @@ if __name__ == '__main__':
     logging.basicConfig(filename=log_dir+"/article_explorer-" + time + "-" + cycle_number.zfill(3) + ".log",
                         level=logging.DEBUG,
                         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+    default_logger = logging.getLogger('')
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.WARNING)
-    console_handler.setFormatter(fmt='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
-    logging.getLogger('').addHandler(console_handler)
+    console_handler.setFormatter(default_logger.handlers[0].formatter)
+    default_logger.addHandler(console_handler)
     # Finish logging config
 
     config = config['article']

--- a/src/article_explorer.py
+++ b/src/article_explorer.py
@@ -109,7 +109,11 @@ def parse_articles(referring_sites, db_keywords, source_sites, twitter_accounts_
         article_iterator = itertools.chain(iter(newspaper_articles), crawlersource_articles)
         processed = 0
         for article in article_iterator:
-            logging.info("Looking: %s"%article.url)
+            print(
+                "%s (Article|%s) %i/%i          \r" %
+                (str(timezone.localtime(timezone.now()))[:-13],
+                 site["name"], processed, article_count))
+            logging.info("Processing %s"%article.url)
             # Check for any new command on communication stream
             check_command()
 
@@ -232,10 +236,6 @@ def parse_articles(referring_sites, db_keywords, source_sites, twitter_accounts_
             warc_creator.create_article_warc(url)
 
             processed += 1
-            print(
-                "%s (Article|%s) %i/%i          \r" %
-                (str(timezone.localtime(timezone.now()))[:-13],
-                 site["name"], processed, article_count))
 
             logging.info("(%s | %i/%i) Finished looking: %s"%(article.url, processed, article_count, article.url))
         logging.info("Finished Site: %s"%site['name'])
@@ -500,6 +500,10 @@ if __name__ == '__main__':
     logging.basicConfig(filename=log_dir+"/article_explorer-" + time + "-" + cycle_number.zfill(3) + ".log",
                         level=logging.DEBUG,
                         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.WARNING)
+    console_handler.setFormatter(fmt='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+    logging.getLogger('').addHandler(console_handler)
     # Finish logging config
 
     config = config['article']

--- a/src/article_explorer.py
+++ b/src/article_explorer.py
@@ -496,7 +496,7 @@ if __name__ == '__main__':
     except:
         cycle_number = "0"
     logging.basicConfig(filename=log_dir+"/article_explorer-" + time + "-" + cycle_number.zfill(3) + ".log",
-                        level=logging.DEBUG,
+                        level=logging.INFO,
                         format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
     default_logger = logging.getLogger('')
     console_handler = logging.StreamHandler()


### PR DESCRIPTION
optimizations for processing articles. improves speed for newspaper and plan b crawler.
* use readability instead of newspaper for parsing when first parsing an article, which is about 3x faster. However, newspaper parsing is still needed if the article is to be added to the database. Most articles do not get added to the database (this is especially true when using plan b crawler), so there is still significant performance gains.
* use sets instead of lists for faster lookup speed
* in get_sources_sites: use lxml for finding links instead of regex (html isn't a regular language!)

tweaks:
* search for urls and twitter authors in articles is now only done within the article content itself rather than throughout the entire article. this should reduce false-positive matches. relevant lines to revert this change:
```
get_sources_twitter: article.summary vs article.html
get_sources_sites: article_links_only=True vs article_links_only=False
```